### PR TITLE
add github templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/help.yml
+++ b/.github/DISCUSSION_TEMPLATE/help.yml
@@ -1,0 +1,20 @@
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      description: What do you need help with?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Any code snippets, error messages, or dependency details that may be related?
+      render: tsx
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: Example
+      description: A link to a minimal reproduction is helpful for collaborative debugging!
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,50 @@
+labels: ['feature request']
+body:
+  - type: dropdown
+    attributes:
+      label: Impacted Product
+      description: Which product does this idea relate to?
+      options:
+        - Dédale
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Goals
+      description: Short list of what the feature request aims to address?
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Non-Goals
+      description: Short list of what the feature request _does not_ aim to address?
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Background
+      description: Discuss prior art, why do you think this feature is needed? Are there current alternatives?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: How should this feature be implemented?
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Upvote and participation
+
+        If you think this feature would be useful to your workflow, please consider to upvote this discussion.
+
+        Don't hesitate to reply to this discussion with any of your ideas you would like to add to this topic.

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Create a bug report.
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is to report bugs inside Bireme Lab products.
+        Feature requests should be opened as [discussions](https://github.com/orgs/bireme-lab/discussions/new?category=ideas).
+
+        Before opening a new issue, please do a [search](https://github.com/bireme-lab/bireme.io/issues) of existing issues and :+1: upvote the existing issue instead. This will result in a quicker resolution.
+
+        If you need help with your own project, you can start a discussion in the ["Help" section](https://github.com/orgs/bireme-lab/discussions/categories/help)
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      description: A step-by-step description of how to reproduce the issue. Screenshots can be provided in the issue body below..
+      placeholder: |
+        1. Open product X
+        2. Click Y
+        3. Z will happen
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current vs. Expected behavior
+      description: A clear and concise description of what the bug is, and what you expected to happen.
+      placeholder: 'Following the steps from the previous section, I expected A to happen, but I observed B instead'
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Provide environment information
+      description: Please give use more informations about your environment.
+      render: bash
+      placeholder: |
+        Device: MacBook Pro 2024 with Apple Silicon M3
+        Browser(s) you tried this on:
+          - Chrome 100.0.0
+          - ...
+        Operating System:
+          Platform: MacOS
+          Arch: arm64
+          Version: Sonoma 14.5 (23F79)
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Which product is related to this bug?
+      options:
+        - 'Not sure'
+        - 'Dédale'
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Any extra information that might help us investigate? Is the issue only happening in a specific browser? etc.
+      placeholder: |
+        I detected this issue is appearing when my computer is running on battery save mode...

--- a/.github/ISSUE_TEMPLATE/2.doc_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.doc_report.yml
@@ -1,0 +1,27 @@
+name: 'Docs Report'
+description: Create a report for Bireme Lab documentation.
+title: 'Docs: '
+labels:
+  - 'Documentation'
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for helping us update our docs!
+  - type: textarea
+    attributes:
+      label: What is the update you wish to see?
+      description: 'Example: I would like to have more examples on how to create a new template using React Email'
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Is there any context that might help us understand?
+      description: A clear description of any added context that might help us understand.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Does the docs page already exist? Please link to it.
+      description: 'Example: https://en.doc.bireme.io/dedale/introduction'
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/orgs/bireme-lab/discussions
+    about: Ask questions and discuss with other community members.
+  - name: Feature request
+    url: https://github.com/orgs/bireme-lab/discussions/new?category=ideas
+    about: Feature or docs requests should be opened as discussions.


### PR DESCRIPTION
This PR deals with addition of templates for bireme.io repository.

I connected Org `discussions` to this repository, so if you go to https://github.com/orgs/bireme-lab/discussions it will sync with discussions on this repository and if you open the discussions tab of this repository it should redirect you to https://github.com/orgs/bireme-lab/discussions. (That's why the templates will be hosted on this one)

For those templates I copied what Next.js did as a base I modified a bit for our purpose.

For now I didn't test "on context" because I need to merge this on `main` to preview the result. 

Some links (such as the doc one) may need to be updated according to final URL we choose for the doc